### PR TITLE
Added nginx status endpoint

### DIFF
--- a/src/etc/nginx/conf.d/status.conf
+++ b/src/etc/nginx/conf.d/status.conf
@@ -1,0 +1,15 @@
+# NGINX status/stats used by datadog, et al.
+server {
+  listen 81;
+  server_name localhost;
+
+  access_log off;
+  allow 127.0.0.1;
+  deny all;
+
+  location /nginx_status {
+    stub_status;
+    # ensures the version information can be retrieved
+    server_tokens on;
+  }
+}


### PR DESCRIPTION
Enable an nginx status page accessible only to local requests for use by datadog and other MMA systems.