### PR TITLE
Fix datadog autodiscovery labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN /test/test.sh
 ############
 # Final 
 ############
+FROM base
 LABEL "com.datadoghq.ad.check_names"='["nginx"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
 LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://%%host%%:81/nginx_status/"}]'
-FROM base


### PR DESCRIPTION
These labels were being added to the previous layer.