### PR TITLE
Mirror Host header to upstream server

### DIFF
--- a/src/etc/nginx/templates/default.conf.template
+++ b/src/etc/nginx/templates/default.conf.template
@@ -1,6 +1,6 @@
 server {
   listen {{ .Env.LISTEN_PORT }};
-  server_name localhost;
+  server_name _;
   add_header X-Request-ID $request_id;
 
   # Security Headers
@@ -11,6 +11,7 @@ server {
   location / {
     proxy_pass {{ .Env.PROXY_REVERSE_URL }};
     proxy_set_header X-Request-ID $request_id;
+    proxy_set_header Host $host;
   }
 
   {{ if .Env.STATIC_LOCATIONS }}

--- a/test/main.go
+++ b/test/main.go
@@ -10,6 +10,8 @@ func ok(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("X-Powered-By", "1")
 	w.Header().Set("X-Rack-Cache", "1")
 	w.Header().Set("X-Runtime", "1")
+	// Forward request host so that it can be evaluated as part of tests
+	w.Header().Set("X-Test-Host", req.Host)
 	fmt.Println("GET /")
 	fmt.Fprintf(w, "ok\n")
 }

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -74,6 +74,11 @@ func TestProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	parsed, err := url.Parse(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	req, err := http.NewRequest("GET", u, nil)
 
 	if err != nil {
@@ -117,5 +122,11 @@ func TestProxy(t *testing.T) {
 		if h == "" {
 			t.Fatalf("Expected %s header to be set", k)
 		}
+	}
+
+	expectedHost := strings.Split(parsed.Host, ":")[0]
+	hostHeader := res.Header.Get("X-Test-Host")
+	if hostHeader != expectedHost {
+		t.Fatalf("Expected Host header to be %s, got %s", expectedHost, hostHeader)
 	}
 }


### PR DESCRIPTION
Pass the `Host` header to upstream server so that application servers may use it. This is generally useful for applications that may use subdomain based routing, and/or want to enforce expected host lists.