### PR TITLE
Bump client_body_buffer_size to 16k

### DIFF
--- a/src/etc/nginx/nginx.conf
+++ b/src/etc/nginx/nginx.conf
@@ -33,10 +33,6 @@ http {
     # Disable etag
     etag off;
 
-    # Lower buffer size to possibly prevent DoS attacks and buffer overflow vulnerabilities.
-    client_body_buffer_size 1k;
-    client_header_buffer_size 1k;
-
     # Nuke some headers we don't want leaking out
     more_clear_headers "X-Powered-By";
     more_clear_headers "X-Rack-Cache";


### PR DESCRIPTION
Drop the overzealous 1k buffer size limit on body buffer size. 16k default is safe: we have memory these days.