### PR TITLE
Allow keepalive value to be adjusted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apk add --no-cache \
         nginx \
         nginx-mod-http-headers-more
 COPY src /
+ENV KEEPALIVE_TIMEOUT=65
 ENV PROXY_UWSGI=0
 ENV LISTEN_PORT=80
 ENV STATIC_LOCATIONS=

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Pair nginx-proxy with your favorite upstream server (wsgi, uwsgi, asgi, et al.)
 | `SILENT` | Silence entrypoint output | No | | |
 | `STATIC_LOCATIONS` | Static asset mappings | No | | |
 | `PROXY_UWSGI` | Whether to use native uwsgi support | No | 0 | 1 |
+| `KEEPALIVE_TIMEOUT` | What value to set HTTP keepalive (This should be higher than your ELB's timeout) | Yes | 65 | |
 
 ### Hosting Static Assets
 

--- a/src/docker-entrypoint.d/00-render-templates.sh
+++ b/src/docker-entrypoint.d/00-render-templates.sh
@@ -4,6 +4,9 @@ set -eo pipefail
 
 source /docker-entrypoint.d/functions
 
+# Render main nginx.conf
+cat "/etc/nginx/nginx.conf.template" | gomplate > "/etc/nginx/nginx.conf"
+
 for f in /etc/nginx/templates/*.template
 do
   final=$(basename "$f")

--- a/src/etc/nginx/nginx.conf.template
+++ b/src/etc/nginx/nginx.conf.template
@@ -24,7 +24,7 @@ http {
     #sendfile       on;
     #tcp_nopush     on;
 
-    keepalive_timeout  65;
+    keepalive_timeout  {{ .Env.KEEPALIVE_TIMEOUT }};
     #gzip  on;
 
     # Don't leak information about this server.

--- a/test/test.sh
+++ b/test/test.sh
@@ -8,6 +8,7 @@ function fail {
 }
 
 LISTEN_PORT="8080" \
+KEEPALIVE_TIMEOUT="65" \
 PROXY_REVERSE_URL="http://localhost:8081" \
 SERVER_NAME="localhost" \
 STATIC_LOCATIONS="/static/:/test/static/" \

--- a/test_uwsgi/test.sh
+++ b/test_uwsgi/test.sh
@@ -8,6 +8,7 @@ function fail {
 }
 
 LISTEN_PORT="8080" \
+KEEPALIVE_TIMEOUT="65" \
 PROXY_REVERSE_URL="localhost:8081" \
 SERVER_NAME="localhost" \
 PROXY_UWSGI="1" \


### PR DESCRIPTION
Some apps have a keepalive value longer than ELB's default 60s. For example, AIS has a timeout value of 120 (gross) so we need to allow the proxy's to be adjusted.