### PR TITLE
Set uwsgi read/send timeouts to keepalive

### DIFF
--- a/src/etc/nginx/templates/default.conf.template
+++ b/src/etc/nginx/templates/default.conf.template
@@ -24,6 +24,8 @@ server {
     uwsgi_param HTTP_X_REQUEST_ID $request_id;
     uwsgi_param HTTP_HOST $host;
     include uwsgi_params;
+    uwsgi_read_timeout {{ .Env.KEEPALIVE_TIMEOUT }};
+    uwsgi_send_timeout {{ .Env.KEEPALIVE_TIMEOUT }};
   }
   {{ else }}
   location / {


### PR DESCRIPTION
Synchronize uwsgi timeouts with keepalive setting, otherwise they will remain at the default 60s, resulting in unexpected timeouts if keepalive is > 60s.