### PR TITLE
Enable more effecient epoll worker selection method

### DIFF
--- a/src/etc/nginx/nginx.conf.template
+++ b/src/etc/nginx/nginx.conf.template
@@ -9,6 +9,7 @@ load_module /usr/lib/nginx/modules/ngx_http_headers_more_filter_module.so;
 
 events {
     worker_connections  1024;
+    use epoll;
 }
 
 http {


### PR DESCRIPTION
We run newish linux, use it.