### PR TITLE
Use upstream module with proxy_pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Pair nginx-proxy with your favorite upstream server (wsgi, uwsgi, asgi, et al.)
 | Environment Variable | Description | Required | Default | Example |
 |----------------------|-------------|----------|---------|---------|
 | `LISTEN_PORT` | Server port | Yes | 80 | |
-| `PROXY_REVERSE_URL` | Upstream server URL | Yes | | http://myapp:8080 |
+| `UPSTREAM_SERVER` | Upstream server | Yes | | myapp:8080 fail_timeout=0, unix://mnt/server.sock |
+| `PROXY_REVERSE_URL` | Upstream server URL (Deprecated, please use UPSTREAM_SERVER) | No | | http://myapp:8080 |
 | `SERVER_NAME` | Allowed server names (hostnames) | Yes | | |
 | `SILENT` | Silence entrypoint output | No | | |
 | `STATIC_LOCATIONS` | Static asset mappings | No | | |
@@ -46,7 +47,7 @@ The syntax of `STATIC_LOCATIONS` is `HOSTED_PATH1:LOCAL_PATH1,HOSTED_PATH2:LOCAL
 ## uWSGI
 
 If you wish to use this service with uWSGI then define `PROXY_UWSGI=1` and set
-`PROXY_REVERSE_URL` to be the uwsgi `--socket` address of your app. (Do not
+`UPSTREAM_SERVER` to be the uwsgi `--socket` address of your app. (Do not
 use `http://`, ex. if your uwsgi server is hosting itself at `--socket :8000`
 then set `PROXY_REVERSE_URL=localhost:8000`.)
 

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# Transform legacy PROXY_REVERSE_URL to UPSTREAM_SERVER
+if [[ -n $PROXY_REVERSE_URL ]]; then
+  export UPSTREAM_SERVER=${PROXY_REVERSE_URL#http://}
+fi
+
 run-parts --exit-on-error /docker-entrypoint.d
 
 exec "$@"

--- a/src/etc/nginx/templates/default.conf.template
+++ b/src/etc/nginx/templates/default.conf.template
@@ -8,6 +8,10 @@ server {
 }
 {{ end }}
 
+upstream app {
+  server {{ .Env.UPSTREAM_SERVER }};
+}
+
 server {
   listen {{ .Env.LISTEN_PORT }};
   server_name {{ .Env.SERVER_NAME }};
@@ -20,7 +24,7 @@ server {
   
   {{ if (eq .Env.PROXY_UWSGI "1") }}
   location / {
-    uwsgi_pass {{ .Env.PROXY_REVERSE_URL }};
+    uwsgi_pass app;
     uwsgi_param HTTP_X_REQUEST_ID $request_id;
     uwsgi_param HTTP_HOST $host;
     include uwsgi_params;
@@ -29,9 +33,10 @@ server {
   }
   {{ else }}
   location / {
-    proxy_pass {{ .Env.PROXY_REVERSE_URL }};
     proxy_set_header X-Request-ID $request_id;
     proxy_set_header Host $host;
+    proxy_redirect off;
+    proxy_pass http://app; 
   }
   {{ end }}
 

--- a/test_uwsgi/test.sh
+++ b/test_uwsgi/test.sh
@@ -9,7 +9,7 @@ function fail {
 
 LISTEN_PORT="8080" \
 KEEPALIVE_TIMEOUT="65" \
-PROXY_REVERSE_URL="localhost:8081" \
+UPSTREAM_SERVER="localhost:8081" \
 SERVER_NAME="localhost" \
 PROXY_UWSGI="1" \
 STATIC_LOCATIONS="/static/:/test/static/" \


### PR DESCRIPTION
Place servers in an upstream module block to allow greater flexibility in definition. `fail_timeout`, etc. can now be specified, and unix sockets and tcp servers both used.