### PR TITLE
Update nginx status endpoint - default to fargate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ RUN /test_uwsgi/test.sh
 FROM base
 LABEL "com.datadoghq.ad.check_names"='["nginx"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://%%host%%:8091/nginx_status/"}]'
+LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://localhost:8091/nginx_status/"}]'


### PR DESCRIPTION
Switch the datadog autodiscovery label so that it works with Fargate by default.