### PR TITLE
Remove trailing comma from logging JSON. 

### DIFF
--- a/src/etc/nginx/includes/log-format.conf
+++ b/src/etc/nginx/includes/log-format.conf
@@ -35,5 +35,5 @@ log_format json_analytics escape=json '{'
   '"server_protocol": "$server_protocol", '                   # request protocol, like HTTP/1.1 or HTTP/2.0
   '"pipe": "$pipe", '                                         # "p" if request was pipelined, "." otherwise
   '"gzip_ratio": "$gzip_ratio", '
-  '"http_cf_ray": "$http_cf_ray",'
+  '"http_cf_ray": "$http_cf_ray"'
 '}';


### PR DESCRIPTION
A comma trailing the final field generates invalid JSON.