### PR TITLE
Add support for STATUS_LISTEN_PORT env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY src /
 ENV KEEPALIVE_TIMEOUT=65
 ENV PROXY_UWSGI=0
 ENV LISTEN_PORT=80
+ENV STATUS_LISTEN_PORT=8091
 ENV HEALTHCHECK_PATH="/lb-status/"
 ENV STATIC_LOCATIONS=
 ENV NO_ACCESS_LOGS=0
@@ -41,4 +42,4 @@ RUN /test_uwsgi/test.sh
 FROM base
 LABEL "com.datadoghq.ad.check_names"='["nginx"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://localhost:8091/nginx_status/"}]'
+LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://%%host%%:%%env_STATUS_LISTEN_PORT%%/nginx_status/"}]'

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Pair nginx-proxy with your favorite upstream server (wsgi, uwsgi, asgi, et al.)
 | Environment Variable | Description | Required | Default | Example |
 |----------------------|-------------|----------|---------|---------|
 | `LISTEN_PORT` | Server port | Yes | 80 | |
+| `STATUS_LISTEN_PORT` | nginx status port | No | 8091 | | 
 | `UPSTREAM_SERVER` | Upstream server | Yes | | myapp:8080 fail_timeout=0, unix://mnt/server.sock |
 | `PROXY_REVERSE_URL` | Upstream server URL (Deprecated, please use UPSTREAM_SERVER) | No | | http://myapp:8080 |
 | `SERVER_NAME` | Allowed server names (hostnames) | Yes | | |
@@ -65,8 +66,11 @@ then set `PROXY_REVERSE_URL=localhost:8000`.)
 
 ## Nginx status
 
-The [nginx status][] page is configured to run at
-http://localhost:8091/nginx_status. This endpoint can be used by Datadog and
+The [nginx status][] page is configured to run at  
+http://localhost:${STATUS_LISTEN_PORT}/nginx_status.
+
+Set the `STATUS_LISTEN_PORT` environment variable when you start the container
+(default: `8091`) to change the port. This endpoint can be used by Datadog and
 other metrics collectors.
 
 ## Development

--- a/src/etc/nginx/conf.d/status.conf.template
+++ b/src/etc/nginx/conf.d/status.conf.template
@@ -1,6 +1,6 @@
 # NGINX status/stats used by datadog, et al.
 server {
-  listen 8091;
+  listen {{ .Env.STATUS_LISTEN_PORT }};
   server_name _;
 
   access_log off;


### PR DESCRIPTION
This PR adds support to `nginx-proxy` so that you can specify which port that it'll listen on for the status/metrics page.

Depended on by https://github.com/secondlife/conductor-poc so that we can have reverse-proxies to backbonecommon and counter without relying on redirects through the ELB.